### PR TITLE
Add support for private key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # rawrsa
-Create PEM-encoded RSA pubilc key from raw modulus / exponent.
+Create PEM-encoded RSA public key from raw modulus and public exponent.
+Optionally create an RSA private key by supplying a raw private exponent.
 
 Inspired by: http://stackoverflow.com/questions/28770426/
 
@@ -14,22 +15,27 @@ gcc -o rawrsa main.o -lcrypto
 ```
 
 ### Usage
-
 ```
 Usage:
  rawrsa [options] <modulus-file>
 
 Options:
- -e, --exponent EXP  Exponent, defaults to 65537
+ -e, --exponent EXP    Exponent, defaults to 65537
+ -p, --privexp  FILE   Private exponent bignum file
 
-$ xxd -p 128.key 
+If --privexp is given, output format is a private key.
+```
+
+Example:
+```
+$ xxd -p raw.key
 6ee3acb0684af2d99d68431e411c790170e126157237ad87b65f8ba1a5a6
 e3a93f92e68051f234ece01d5076f2b4d344d48cc332bf76c55cac8a08af
 5c667acac1332755b8dacdf290ae10e5e1d8442f8f3a21524be32d0823a1
 6c20833e3d4a9e410924a79f7c3fa57b69b33662ef0653e0267416f69b78
 07a837dda378e39c
 
-$ ./rawrsa -e 65537 128.key  | openssl rsa -pubin -text
+$ ./rawrsa -e 65537 raw.key  | openssl rsa -pubin -text
 Public-Key: (1023 bit)
 Modulus:
     6e:e3:ac:b0:68:4a:f2:d9:9d:68:43:1e:41:1c:79:
@@ -49,5 +55,6 @@ cjeth7Zfi6GlpuOpP5LmgFHyNOzgHVB28rTTRNSMwzK/dsVcrIoIr1xmesrBMydV
 uNrN8pCuEOXh2EQvjzohUkvjLQgjoWwggz49Sp5BCSSnn3w/pXtpszZi7wZT4CZ0
 FvabeAeoN92jeOOcAgMBAAE=
 -----END PUBLIC KEY-----
-
 ```
+
+See test.sh for advanced usage and test.

--- a/SConstruct
+++ b/SConstruct
@@ -1,5 +1,6 @@
 env = Environment(
-    CCFLAGS=['-Wall','-Werror','-g']
+    CCFLAGS=['-Wall','-Werror','-g'],
+    #CPPDEFINES={'DEBUG': None},
 )
 
 env.Program('rawrsa', ['main.c'], LIBS=['crypto'])

--- a/SConstruct
+++ b/SConstruct
@@ -3,4 +3,11 @@ env = Environment(
     #CPPDEFINES={'DEBUG': None},
 )
 
-env.Program('rawrsa', ['main.c'], LIBS=['crypto'])
+env.Program(
+    target = 'rawrsa',
+    source = [
+        'main.c',
+        'librsaconverter.c',
+    ],
+    LIBS=['crypto'],
+)

--- a/generate_rsa_key.py
+++ b/generate_rsa_key.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+# Adapted from:
+# https://gist.github.com/ostinelli/aeebf4643b7a531c248a353cee8b9461
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+
+def parse_args():
+    import argparse
+    ap = argparse.ArgumentParser()
+    ap.add_argument('-s', '--size', dest='key_size', type=int, default=2048,
+            help="Key size (default 2048)")
+    ap.add_argument('-e', '--exp', dest='public_exp', type=int, default=65537,
+            help="Public exponent (default 65537)")
+    return ap.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    print(f"Generating key ({args.key_size} bits)")
+    private_key = rsa.generate_private_key(
+            public_exponent=args.public_exp,
+            key_size=args.key_size,
+            backend=default_backend(),
+            )
+
+    privnums = private_key.private_numbers()
+    pubnums = privnums.public_numbers
+
+    print(f"d: {privnums.d}")
+    print(f"e: {pubnums.e}")
+    print(f"n: {pubnums.n}")
+
+    # Write raw binary bignum files
+    def write_bn(path, bn):
+        with open(path, 'wb') as f:
+            f.write(bn.to_bytes(args.key_size//8, 'big'))
+
+    path = "pubmod.bin"
+    write_bn(path, pubnums.n)
+    print(f"Raw bublic modulus (n) written to {path}")
+
+    path = "privexp.bin"
+    write_bn(path, privnums.d)
+    print(f"Raw private exponent (d) written to {path}")
+
+    def save_file(filename, content):
+        with open(filename, 'wb') as f:
+            f.write(content)
+
+    # Write PEM private key
+    pem = private_key.private_bytes(
+	encoding=serialization.Encoding.PEM,
+	format=serialization.PrivateFormat.TraditionalOpenSSL,
+	encryption_algorithm=serialization.NoEncryption()
+    )
+    path = "private.pem"
+    save_file(path, pem)
+    print(f"Private key written to {path}")
+
+    # generate public key
+    public_key = private_key.public_key()
+    pem = public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    path = "public.pem"
+    save_file(path, pem)
+    print(f"Public key written to {path}")
+
+
+if __name__ == '__main__':
+    main()

--- a/librsaconverter.c
+++ b/librsaconverter.c
@@ -1,0 +1,356 @@
+/* librsaconverter.c 
+
+Copyright 2009 Mounir IDRASSI (mounir.idrassi@idrix.fr)
+
+This file is part of RSAConverter.
+
+The RSAConverter is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at your
+option) any later version.
+
+The RSAConverter is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the RSAConverter.  If not, see http://www.gnu.org/licenses/.  */
+
+#include "librsaconverter.h"
+#include <time.h>
+
+/*
+* Implement the extended GCD algorithm that is missing from OpenSSL
+*/
+static void extended_gcd(BIGNUM* v, BIGNUM* a, BIGNUM* b, BIGNUM* x, BIGNUM* y)
+{
+   BN_CTX* ctx = BN_CTX_new();
+   BIGNUM* g = NULL;
+   BIGNUM* u = NULL;
+   BIGNUM* A = NULL;
+   BIGNUM* B = NULL;
+   BIGNUM* C = NULL;
+   BIGNUM* D = NULL;
+   BIGNUM* tmp = NULL;
+   BIGNUM* xx = NULL;
+   BIGNUM* yy = NULL;
+
+   BN_CTX_start(ctx);
+
+   g = BN_CTX_get(ctx);
+   u = BN_CTX_get(ctx);
+   A = BN_CTX_get(ctx);
+   B = BN_CTX_get(ctx);
+   C = BN_CTX_get(ctx);
+   D = BN_CTX_get(ctx);
+   tmp = BN_CTX_get(ctx);
+   xx = BN_CTX_get(ctx);
+   yy = BN_CTX_get(ctx);
+
+   BN_set_word(g, 1);
+   BN_copy(xx, x);
+   BN_copy(yy, y);
+
+   while (!BN_is_odd(xx) && !BN_is_odd(yy))
+   {
+      BN_rshift1(xx, xx);
+      BN_rshift1(yy, yy);
+      BN_lshift1(g,g);
+   }
+
+   BN_copy(u, xx);
+   BN_copy(v, yy);
+   BN_set_word(A, 1);
+   BN_set_word(B, 0);
+   BN_set_word(C, 0);
+   BN_set_word(D, 1);
+
+   while (1)
+   {
+      while (!BN_is_odd(u))
+      {
+         BN_rshift1(u, u);
+         if (!BN_is_odd(A) && !BN_is_odd(B))
+         {
+            BN_rshift1(A, A);
+            BN_rshift1(B, B);
+         }
+         else
+         {
+            BN_add(A,A,yy);
+            BN_rshift1(A, A);
+
+            BN_sub(tmp, B, xx);
+            BN_rshift1(B, tmp);
+         }
+      }
+
+      while (!BN_is_odd(v))
+      {
+         BN_rshift1(v, v);
+         if (!BN_is_odd(C) && !BN_is_odd(D))
+         {
+            BN_rshift1(C, C);
+            BN_rshift1(D, D);
+         }
+         else
+         {
+            BN_add(C,C,yy);
+            BN_rshift1(C, C);
+
+            BN_sub(tmp, D, xx);
+            BN_rshift1(D, tmp);
+         }
+      }
+
+      if (BN_cmp(u, v) >= 0)
+      {
+         BN_sub(tmp, u, v);
+         BN_copy(u, tmp);
+
+         BN_sub(tmp, A, C);
+         BN_copy(A, tmp);
+
+         BN_sub(tmp, B, D);
+         BN_copy(B, tmp);
+      }
+      else
+      {
+         BN_sub(tmp, v, u);
+         BN_copy(v, tmp);
+
+         BN_sub(tmp, C, A);
+         BN_copy(C, tmp);
+
+         BN_sub(tmp, D, B);
+         BN_copy(D, tmp);
+      }
+
+      if (BN_is_zero(u))
+      {
+         BN_copy(a, C);
+         BN_copy(b, D);
+         BN_mul(tmp, g, v, ctx);
+         BN_copy(v, tmp);
+         break;
+      }
+   }
+
+   BN_CTX_end(ctx);
+   BN_CTX_free(ctx);
+}
+
+
+int CheckRsaSfmKey(const BIGNUM* n, const BIGNUM* e, const BIGNUM* d)
+{
+   BIGNUM *m, *c, *m1;
+   BN_CTX *ctx;
+   int iResult = 0;
+
+   ctx = BN_CTX_new();
+   BN_CTX_start(ctx);
+
+   m = BN_CTX_get(ctx);
+   m1 = BN_CTX_get(ctx);
+   c = BN_CTX_get(ctx);
+
+   BN_pseudo_rand_range(m, n);
+
+   BN_mod_exp(c, m, e, n, ctx);
+   BN_mod_exp(m1, c, d, n, ctx);
+
+   iResult = (BN_cmp(m, m1) == 0)? 1 : 0;
+
+   BN_CTX_end(ctx);
+   BN_CTX_free(ctx);
+   return iResult;
+}
+
+
+int SfmToCrt( const BIGNUM* n,
+             const BIGNUM* e,
+             const BIGNUM* d,
+             BIGNUM* p,
+             BIGNUM* q,
+             BIGNUM* dp,
+             BIGNUM* dq,
+             BIGNUM* u)
+{
+   int iResult = 0;
+   BN_CTX* ctx;
+   BIGNUM  *k, *g, *kt, *rem;
+   BIGNUM  *gk, *sq;
+   BIGNUM* Gcd;
+   unsigned long i,t;
+   time_t start, diff;
+
+   ctx = BN_CTX_new();
+   BN_CTX_start(ctx);
+
+   k = BN_CTX_get(ctx);
+   kt = BN_CTX_get(ctx);  
+   rem = BN_CTX_get(ctx);
+   g = BN_CTX_get(ctx);
+   gk = BN_CTX_get(ctx);
+   sq = BN_CTX_get(ctx);
+   Gcd = BN_CTX_get(ctx);
+
+   BN_mul(k, e, d, ctx);
+   BN_sub_word(k, 1);
+
+   t = 0;
+   while(!BN_is_bit_set(k,t))
+      t++;
+
+   start = time(NULL);
+
+   while(1)
+   {
+      diff = time(NULL) - start;
+      if (diff > SFMTOCRT_TIMEOUT)
+         break;
+
+
+      BN_copy(kt, k);
+      BN_pseudo_rand_range(g, n);
+
+      for(i=0;i<t;i++)
+      {
+         BN_rshift1(kt, kt);
+         BN_mod_exp(gk, g, kt, n, ctx);         
+
+         if (!BN_is_one(gk))
+         {
+            BN_sqr(sq, gk, ctx);
+            BN_mod(rem, sq, n, ctx);
+
+            if(BN_is_one(rem))
+               break;
+         }
+      }
+
+      if(i < t)
+      {
+         BN_sub_word(gk, 1);
+         BN_gcd(Gcd, gk, n, ctx);
+         if(!BN_is_one(Gcd))
+            break;
+      }
+   }
+
+   if (diff <= SFMTOCRT_TIMEOUT)
+   {
+      BN_copy(p, Gcd);
+      BN_div(q, NULL, n, p, ctx);
+
+      if (BN_is_prime_ex(p,50, ctx, NULL) && BN_is_prime_ex(q,50, ctx, NULL))
+      {
+         if (BN_cmp(q, p) > 0)
+         {
+            BN_swap(p,q);
+         }
+
+         BN_sub_word(p, 1);
+         BN_sub_word(q, 1);
+
+         BN_mod(dp, d, p, ctx);
+         BN_mod(dq, d, q, ctx);
+
+         BN_add_word(p, 1);
+         BN_add_word(q, 1);
+
+         BN_mod_inverse(u, q, p, ctx);
+
+         iResult = 1;
+      }
+   }
+
+   BN_CTX_end(ctx);
+   BN_CTX_free(ctx);
+
+   return iResult;
+}
+
+
+int CrtToSfm( const BIGNUM* p,
+             const BIGNUM* q,
+             const BIGNUM* dp,
+             const BIGNUM* dq,
+             BIGNUM* n,
+             BIGNUM* e,
+             BIGNUM* d)
+{
+   BN_CTX* ctx = BN_CTX_new();
+   int iResult = 0;
+   BIGNUM *g, *v, *diff, *k, *r, *l, *u;
+   BIGNUM *pp, *qq, *dpp, *dqq;
+
+   BN_CTX_start(ctx);
+
+   pp = BN_CTX_get(ctx);
+   qq = BN_CTX_get(ctx);
+   dpp = BN_CTX_get(ctx);
+   dqq = BN_CTX_get(ctx);
+
+   g = BN_CTX_get(ctx);
+   v = BN_CTX_get(ctx);
+   u = BN_CTX_get(ctx);
+   diff = BN_CTX_get(ctx);
+   k = BN_CTX_get(ctx);
+   r = BN_CTX_get(ctx);
+   l = BN_CTX_get(ctx);
+
+   BN_copy(pp, p);
+   BN_copy(qq, q);
+   BN_copy(dpp, dp);
+   BN_copy(dqq, dq);
+
+   BN_mul(n, pp, qq, ctx);
+
+   if(BN_cmp(dpp,dqq) < 0)
+   {
+      BN_swap(dpp,dqq);
+      BN_swap(pp,qq);
+   }
+
+   BN_sub_word(pp, 1);
+   BN_sub_word(qq, 1);
+
+   extended_gcd(g,u,v,pp,qq);
+   BN_sub(diff,dpp,dqq);
+   BN_div(k, NULL, diff, g, ctx);
+
+   BN_mul(r,k,u, ctx);
+   BN_mul(k,r,pp, ctx);
+   BN_sub(d, dpp, k);
+
+   BN_mul(k,pp,qq, ctx);
+   BN_div(l, NULL,k,g, ctx);
+
+   BN_mod(r,d,l, ctx);
+   if (!BN_is_zero(r) && BN_is_negative(r))
+      BN_add(d,l,r);
+   else
+      BN_copy(d,r);
+
+   BN_mod_inverse(e,d,l, ctx);
+   BN_mod_inverse(d,e,k, ctx);
+
+   if (!BN_is_zero(d) && !BN_is_negative(d))
+   {
+      BN_mod(r,d,pp, ctx);
+      if (0 == BN_cmp(r, dpp))
+      {
+         if (CheckRsaSfmKey(n,e,d))
+            iResult = 1;
+      }
+   }
+
+
+   BN_CTX_end(ctx);
+   BN_CTX_free(ctx);
+
+   return iResult;
+}
+

--- a/librsaconverter.h
+++ b/librsaconverter.h
@@ -1,0 +1,78 @@
+/* librsaconverter.h 
+
+Copyright 2009 Mounir IDRASSI (mounir.idrassi@idrix.fr)
+
+This file is part of RSAConverter.
+
+The RSAConverter is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 3 of the License, or (at your
+option) any later version.
+
+The RSAConverter is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the RSAConverter.  If not, see http://www.gnu.org/licenses/.  */
+
+#ifndef LIBRSACONVERTER_H
+#define LIBRSACONVERTER_H
+
+#include <openssl/bn.h>
+
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
+
+   /*
+   * Timeout in seconds for the the conversion
+   * from CRT to SFM in case the input parameters
+   * are wrong and there is no valid SFM paramters
+   */
+#define SFMTOCRT_TIMEOUT  (5*60)
+
+   /*
+   * Check the consistency of an RSA SFM key
+   *
+   * return 1 on success, 0 on failure
+   */
+   int CheckRsaSfmKey(const BIGNUM* n, const BIGNUM* e, const BIGNUM* d);
+
+   /*
+   * compute the RSA CRT components from the modulus,
+   * the public exponent and the private exponent
+   *
+   * return 1 on succes, 0 on failure (timeout)
+   */
+   int SfmToCrt( const BIGNUM* n,
+      const BIGNUM* e,
+      const BIGNUM* d,
+      BIGNUM* p,
+      BIGNUM* q,
+      BIGNUM* dp,
+      BIGNUM* dq,
+      BIGNUM* u);
+
+   /*
+   * compute the RSA modulus, the public exponent and 
+   * the private exponent from the RSA CRT components
+   *
+   * return 1 on succes, 0 on failure (inconsistency)
+   */
+   int CrtToSfm( const BIGNUM* p,
+      const BIGNUM* q,
+      const BIGNUM* dp,
+      const BIGNUM* dq,
+      BIGNUM* n,
+      BIGNUM* e,
+      BIGNUM* d);
+
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif

--- a/main.c
+++ b/main.c
@@ -4,8 +4,9 @@
 #include <limits.h>
 #include <getopt.h>
 #include <openssl/bn.h>
-#include <openssl/rsa.h>
+#include <openssl/err.h>
 #include <openssl/pem.h>
+#include <openssl/rsa.h>
 
 #define MAX_MOD_SIZE        (OPENSSL_RSA_MAX_MODULUS_BITS * CHAR_BIT)
 #define DEFAULT_EXPONENT    65537ul
@@ -63,13 +64,16 @@ static void usage(void)
         " %s [options] <modulus-file>\n"
         "\n"
         "Options:\n"
-        " -e, --exponent EXP  Exponent, defaults to %lu\n"
-        "\n",
+        " -e, --exponent EXP    Exponent, defaults to %lu\n"
+        " -p, --privexp  FILE   Private exponent bignum file\n"
+        "\n"
+        "If --privexp is given, output format is a private key.\n",
         appname, DEFAULT_EXPONENT);
 }
 
 static unsigned long exponent = DEFAULT_EXPONENT;
 static const char *modfile;
+static const char *privexp_file;
 
 static void parse_opts(int argc, char *argv[])
 {
@@ -78,10 +82,11 @@ static void parse_opts(int argc, char *argv[])
 
     static struct option long_options[] = {
         {"exponent",    required_argument,  0,  'e'},
+        {"privexp",     required_argument,  0,  'p'},
         {NULL,          0,                  0,  0}
     };
 
-    while ((opt = getopt_long(argc, argv, "e:",
+    while ((opt = getopt_long(argc, argv, "e:p:",
                     long_options, &long_index)) != -1) {
         switch (opt) {
             case 'e':
@@ -89,6 +94,10 @@ static void parse_opts(int argc, char *argv[])
                     err("Invalid exponent: \"%s\"\n", optarg);
                     exit(1);
                 }
+                break;
+
+            case 'p':
+                privexp_file = optarg;
                 break;
 
             default:
@@ -157,6 +166,7 @@ out:
 int main(int argc, char *argv[])
 {
     BIGNUM *mod = NULL;
+    BIGNUM *privexp = NULL;
 
     appname = basename(argv[0]);
     parse_opts(argc, argv);
@@ -165,8 +175,15 @@ int main(int argc, char *argv[])
     if (!mod) {
         return 1;
     }
-    print_bn("Modulus", mod);
-   
+    print_bn("Public modulus (n)", mod);
+
+    if (privexp_file) {
+        privexp = read_bignum_file(privexp_file);
+        if (!privexp) {
+            return 1;
+        }
+        print_bn("Private exponent (d)", privexp);
+    }
 
     /* Parse exponent */
     BIGNUM *exp = BN_new();
@@ -174,7 +191,7 @@ int main(int argc, char *argv[])
         err("BN_set_word() failed\n");
         return 1;
     }
-    print_bn("Exponent", exp);
+    print_bn("Public exponent", exp);
 
     /* Create RSA key */
     RSA *rsa = RSA_new();
@@ -182,12 +199,36 @@ int main(int argc, char *argv[])
         err("RSA_new() failed\n");
         return 1;
     }
-    RSA_set0_key(rsa, mod, exp, NULL);
+    RSA_set0_key(rsa, mod, exp, privexp);
 
-    /* Write PEM-encoded RSA public key to stdout */
-    if (!PEM_write_RSA_PUBKEY(stdout, rsa)) {
-        err("PEM_write_RSAPublicKey() failed\n");
-        return 1;
+    if (privexp) {
+#if 0
+        /* Check the private key */
+        /**
+         * XXX: This doesn't work because we dont' have p and q:
+         * http://openssl.6102.n7.nabble.com/RSA-check-key-failure-0x407b093-value-missing-td50723.html
+         * https://github.com/openssl/openssl/blob/OpenSSL_1_1_1d/crypto/rsa/rsa_chk.c#L26-L30
+         */
+        if (RSA_check_key(rsa) != 1) {
+            err("Invalid private RSA key: %s\n",
+                    ERR_error_string(ERR_get_error(), NULL));
+        }
+        err("RSA private key pair is valid\n");
+#endif
+
+
+        /* Write PEM-encoded RSA private key to stdout */
+        if (!PEM_write_RSAPrivateKey(stdout, rsa, NULL, NULL, 0, NULL, NULL)) {
+            err("PEM_write_RSAPrivateKey() failed\n");
+            return 1;
+        }
+    }
+    else {
+        /* Write PEM-encoded RSA public key to stdout */
+        if (!PEM_write_RSA_PUBKEY(stdout, rsa)) {
+            err("PEM_write_RSAPublicKey() failed\n");
+            return 1;
+        }
     }
 
     return 0;

--- a/main.c
+++ b/main.c
@@ -14,13 +14,22 @@
 #define err(fmt, ...)   \
     fprintf(stderr, "%s: " fmt, appname, ##__VA_ARGS__)
 
+#ifdef DEBUG
+# define USE_DEBUG  1
+#else
+# define USE_DEBUG  0
+#endif
+
+#define dbg(fmt, ...)   \
+    if (USE_DEBUG) fprintf(stderr, fmt, ##__VA_ARGS__)
+
 static const char* appname;
 
 static void print_bn(const char *what, const BIGNUM *bn)
 {
 #ifdef DEBUG
     char *str = BN_bn2hex(bn);
-    printf("%s (hex): %s\n", what, str);
+    fprintf(stderr, "%s (hex): %s\n", what, str);
     OPENSSL_free(str);
 #endif
 }

--- a/main.c
+++ b/main.c
@@ -282,5 +282,6 @@ int main(int argc, char *argv[])
         }
     }
 
+    RSA_free(rsa);
     return 0;
 }

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+EXP=65537
+
+scons
+./generate_rsa_key.py -e $EXP
+
+# Reconstruct public key
+./rawrsa -e $EXP pubmod.bin > public_out.pem
+
+# Reconstruct private key
+./rawrsa -e $EXP --privexp privexp.bin pubmod.bin > private_out.pem
+
+# Compare
+md5sum *.pem
+
+diff public.pem public_out.pem
+echo "Reconstructed public key matches generated PEM!"
+
+diff private.pem private_out.pem
+echo "Reconstructed private key matches generated PEM!"

--- a/test.sh
+++ b/test.sh
@@ -9,8 +9,8 @@ scons
 # Reconstruct public key
 ./rawrsa -e $EXP pubmod.bin > public_out.pem
 
-# Reconstruct private key
-./rawrsa -e $EXP --privexp privexp.bin pubmod.bin > private_out.pem
+# Reconstruct expanded private key
+./rawrsa -e $EXP --privexp privexp.bin --expand pubmod.bin > private_out.pem
 
 # Compare
 md5sum *.pem


### PR DESCRIPTION
This adds an optional `-p`/`--privexp` command-line option which enables supplying an optional raw private exponent. If this option is given, the output will be an `RSA PRIVATE KEY` instead.

Additionally, if a new `-x`/`--expand` option is given, the private key is expanded from SFM (Straightforward Method) form (with just `n`, `e`, `d`) to full CRT (Chinese Remainder Theorem) form (with `p`, `q`, `dp`, `dq`, `u`). With this expansion, we can regenerate the exact `RSA PRIVATE KEY` file.

Private key expansion and consistency checking provided by `librsaconverter` (https://sourceforge.net/p/rsaconverter/).

Closes #3