### PR TITLE
Remove compat RSA_set0_key for openssl pre-1.1

### DIFF
--- a/main.c
+++ b/main.c
@@ -11,7 +11,6 @@
 
 #include "librsaconverter.h"
 
-#define MAX_MOD_SIZE        (OPENSSL_RSA_MAX_MODULUS_BITS * CHAR_BIT)
 #define DEFAULT_EXPONENT    65537ul
 
 #define err(fmt, ...)   \
@@ -36,38 +35,6 @@ static void print_bn(const char *what, const BIGNUM *bn)
     OPENSSL_free(str);
 #endif
 }
-
-/**
- * OpenSSL pre-1.1 compatibility
- * https://wiki.openssl.org/index.php/OpenSSL_1.1.0_Changes
- */
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-static int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d)
-{
-    /* If the fields n and e in r are NULL, the corresponding input
-     * parameters MUST be non-NULL for n and e.  d may be
-     * left NULL (in case only the public key is used).
-     */
-    if ((r->n == NULL && n == NULL)
-        || (r->e == NULL && e == NULL))
-        return 0;
-
-    if (n != NULL) {
-        BN_free(r->n);
-        r->n = n;
-    }
-    if (e != NULL) {
-        BN_free(r->e);
-        r->e = e;
-    }
-    if (d != NULL) {
-        BN_free(r->d);
-        r->d = d;
-    }
-
-    return 1;
-}
-#endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */
 
 static void usage(void)
 {


### PR DESCRIPTION
Since #4, we now use other `RSA_*` functions, too, for key member access and I don't feel like adding compatibility shims.